### PR TITLE
testing de #4 y #21, cambio en la gestión de secretos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,7 @@ ENV/
 .vagrant
 
 # secrets
-.secrets
-.vscode/settings.json
+secrets_settings.py
+
+# vscode settings
+.vscode/

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -144,5 +144,5 @@ def authenticate_via_magic_link(request: HttpRequest, token: str):
         return HttpResponseBadRequest(content="Link has expired, request a new one")
     cache.delete(token)
     user = User.objects.get(email=email)
-    login(request, user)
+    login(request, user, backend='django.contrib.auth.backends.ModelBackend')
     return redirect(URL_BASE)

--- a/decide/base/templates/base_dashboard.html
+++ b/decide/base/templates/base_dashboard.html
@@ -29,21 +29,21 @@
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                        <li class="nav-item">
+                        <li class="nav-item" id="nav-home">
                             <a class="nav-link" href="/base/">Home</a>
                         </li>
 
                         {% if user.is_staff %}
                         <li class="nav-item">
-                            <li class="nav-item me-3 me-lg-0 dropdown">
+                            <li class="nav-item me-3 me-lg-0 dropdown" id="nav-administration">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown"
                                 aria-expanded="false">
                                 Administration
                                 </a>
                                 <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                                    <li><a class="dropdown-item" href="/users">Users</a></li>
-                                    <li><a class="dropdown-item" href="#">Votings</a></li>
-                                    <li><a class="dropdown-item" href="{% url 'censo' %}">Census</a></li>
+                                    <li id="nav-users"><a class="dropdown-item" href="/users">Users</a></li>
+                                    <li id="nav-votings"><a class="dropdown-item" href="#">Votings</a></li>
+                                    <li id="nav-census"><a class="dropdown-item" href="{% url 'censo' %}">Census</a></li>
                                     
                                 </ul>
                             </li>
@@ -54,7 +54,7 @@
                     </ul>
 
                     <!-- Usuario -->
-                    <ul class="navbar-nav d-flex flex-row ms-auto me-3">
+                    <ul class="navbar-nav d-flex flex-row ms-auto me-3" id="nav-user">
                         <li class="nav-item me-3 me-lg-0 dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown1" role="button" data-bs-toggle="dropdown"
                             aria-expanded="false">

--- a/decide/base/tests.py
+++ b/decide/base/tests.py
@@ -51,8 +51,7 @@ class BaseTestCase(APITestCase):
         self.client.credentials()
 
 
-#Test de navegación
-
+#Navigation tets
 class NavBarTestCase(StaticLiveServerTestCase):
 
     def setUp(self):
@@ -171,15 +170,18 @@ class IndexViewTestCase(StaticLiveServerTestCase):
         self.driver.find_element(By.ID, "id_username").send_keys(user)
         self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
 
-        self.assertTrue(open_msg in self.driver.page_source, msg='Expected message "You do not have open votings"')
-        self.assertTrue(waiting_msg in self.driver.page_source, msg='Expected message "You do not have votings waiting for result"')
-        self.assertTrue(previous_msg in self.driver.page_source, msg='Expected message "You do not have votings to visualize"')
+        self.assertTrue(open_msg in self.driver.page_source, msg=f'Expected message "{open_msg}"')
+        self.assertTrue(waiting_msg in self.driver.page_source, msg=f'Expected message "{waiting_msg}"')
+        self.assertTrue(previous_msg in self.driver.page_source, msg=f'Expected message "{previous_msg}"')
 
 
     def test_indexVotingsExist(self, user='admin', password='qwerty'):
         '''
         Test if votings are shown
         '''
+        open_msg='You do not have open votings'
+        waiting_msg='You do not have votings waiting for result'
+        previous_msg='You do not have votings to visualize'
         waiting_voting_name = 'waiting voting'
 
         self.driver.get(f"{self.live_server_url}{LOGIN_URL}")
@@ -193,6 +195,10 @@ class IndexViewTestCase(StaticLiveServerTestCase):
             self.assertRegex(vote_link,'\/booth\/[0-9]*', msg='Vote link does not match the pattern "\/booth\/[0-9]*"')
             self.assertRegex(result_link,'\/visualizer\/[0-9]*', msg='Results link does not match the pattern "\/visualizer\/[0-9]*"')
             self.assertTrue(waiting_voting_name in self.driver.page_source,msg='Voting waiting for result now found')
+
+            self.assertFalse(open_msg in self.driver.page_source, msg=f'Not expected message "{open_msg}"')
+            self.assertFalse(waiting_msg in self.driver.page_source, msg=f'Not expected message "{waiting_msg}"')
+            self.assertFalse(previous_msg in self.driver.page_source, msg=f'Not expected message "{previous_msg}"')
         except:
             self.assertRaises(NoSuchElementException,self.driver.find_element_by_link_text('Vote'), msg='Vote link not found')
             self.assertRaises(NoSuchElementException,self.driver.find_element_by_link_text('Results'), msg='Results link not found')

--- a/decide/base/tests.py
+++ b/decide/base/tests.py
@@ -1,8 +1,19 @@
 from django.contrib.auth.models import User
+from voting.models import Voting
+from census.models import Census
+from decide.settings import LOGIN_URL
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
 from base import mods
+
+
+#selenium
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
 
 
 class BaseTestCase(APITestCase):
@@ -34,3 +45,141 @@ class BaseTestCase(APITestCase):
 
     def logout(self):
         self.client.credentials()
+
+
+#Test de navegación
+
+class NavBarTestCase(StaticLiveServerTestCase):
+
+    def setUp(self):
+        #Load base test functionality for decide
+        self.base = BaseTestCase()
+        self.base.setUp()
+
+        options = webdriver.ChromeOptions()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
+       
+            
+    def tearDown(self):           
+        super().tearDown()
+        self.driver.quit()
+        self.base.tearDown()
+
+
+    def test_noAdminCorrectNavbar(self, user='noadmin', password='qwerty'):
+        '''
+        Test if a non admin user can access to the Home link in the navbar
+        '''
+
+        self.driver.get(f"{self.live_server_url}{LOGIN_URL}")
+        self.driver.find_element(By.ID, "id_username").send_keys(user)
+        self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
+
+        home_nav_nink_exists = len(self.driver.find_elements(By.ID, "nav-home"))
+        admin_nav_link_exists = len(self.driver.find_elements(By.ID, "nav-administration"))
+        user_nav_link_exists = len(self.driver.find_elements(By.ID, "nav-user"))
+
+        self.assertTrue(home_nav_nink_exists == 1, msg='Navbar link called "Home" not found')
+        self.assertTrue(admin_nav_link_exists == 0, msg='Navbar link called "Administration" found, expected not to be found if logged as non admin user')
+        self.assertTrue(user_nav_link_exists == 1, msg='Navbar dropdown with user data not found')
+
+
+    def test_adminCorrectNavbar(self, user='admin', password='qwerty'):
+        '''
+        Test if an admin can access to Home and Administration dropdown in the navbar
+        '''
+
+        self.driver.get(f"{self.live_server_url}{LOGIN_URL}")
+        self.driver.find_element(By.ID, "id_username").send_keys(user)
+        self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
+
+        home_nav_nink_exists = len(self.driver.find_elements(By.ID, "nav-home"))
+        admin_nav_link_exists = len(self.driver.find_elements(By.ID, "nav-administration"))
+        user_nav_link_exists = len(self.driver.find_elements(By.ID, "nav-user"))
+
+        self.assertTrue(home_nav_nink_exists == 1, msg='Navbar link called "Home" not found')
+        self.assertTrue(admin_nav_link_exists == 1, msg='Navbar link called "Administration" not found')
+        self.assertTrue(user_nav_link_exists == 1, msg='Navbar dropdown with user data not found')
+
+
+class IndexViewTestCase(StaticLiveServerTestCase):
+
+    def setUp(self):
+        #Load base test functionality for decide
+        self.base = BaseTestCase()
+        self.base.setUp()
+
+        #Create votings in different states and relate a user via census
+        voter_id = User.objects.only('id').get(username='admin').id
+
+        voting_open = Voting(name='open voting', start_date='2000-01-01')
+        voting_open.save()
+        census1 = Census(voter_id=voter_id, voting_id=voting_open.id)
+        census1.save()
+
+        voting_waiting = Voting(name='waiting voting', end_date='2000-01-01')
+        voting_waiting.save()
+        census2 = Census(voter_id=voter_id, voting_id=voting_waiting.id)
+        census2.save()
+
+        voting_tally = Voting(name='tally voting', tally='{}')
+        voting_tally.save()
+        census3 = Census(voter_id=voter_id, voting_id=voting_tally.id)
+        census3.save()
+
+
+        options = webdriver.ChromeOptions()
+        options.headless = True
+        self.driver = webdriver.Chrome(options=options)
+
+            
+    def tearDown(self):           
+        super().tearDown()
+        self.driver.quit()
+        self.base.tearDown()
+
+    def test_indexPermissionCheck(self):
+        '''
+        Test that a non logged user cannot access index
+        '''
+        login_url = f'{self.live_server_url}{LOGIN_URL}'
+
+        self.driver.get(f"{self.live_server_url}")
+        url_value_after_get_index = self.driver.current_url
+        self.driver.get(f"{self.live_server_url}/base")
+        url_value_after_get_base = self.driver.current_url
+
+        self.assertRegex(url_value_after_get_index,f'^{login_url}')
+        self.assertRegex(url_value_after_get_base,f'^{login_url}')
+
+    def test_indexNoVotingExist(self, user='noadmin', password='qwerty'):
+        '''
+        Test if the correct message is shown when the user has no votings associated via census
+        '''
+        openMsg='You do not have open votings'
+        waitingMsg='You do not have votings waiting for result'
+        previousMsg='You do not have votings to visualize'
+
+        self.driver.get(f"{self.live_server_url}{LOGIN_URL}")
+        self.driver.find_element(By.ID, "id_username").send_keys(user)
+        self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
+
+        self.assertTrue(openMsg in self.driver.page_source, msg='Expected message "You do not have open votings"')
+        self.assertTrue(waitingMsg in self.driver.page_source, msg='Expected message "You do not have votings waiting for result"')
+        self.assertTrue(previousMsg in self.driver.page_source, msg='Expected message "You do not have votings to visualize"')
+
+
+    def test_indexVotingsExist(self, user='admin', password='qwerty'):
+        '''
+        Test if votings are shown
+        '''
+        self.driver.get(f"{self.live_server_url}{LOGIN_URL}")
+        self.driver.find_element(By.ID, "id_username").send_keys(user)
+        self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
+
+        vote_link = self.driver.find_element_by_link_text('Vote').get_attribute('href')
+        result_link = self.driver.find_element_by_link_text('Results').get_attribute('href')
+
+        self.assertRegex(vote_link,'\/booth\/[0-9]*', msg='Vote link does not match the pattern "\/booth\/[0-9]*"')
+        self.assertRegex(result_link,'\/visualizer\/[0-9]*', msg='Results link does not match the pattern "\/visualizer\/[0-9]*"')

--- a/decide/base/tests.py
+++ b/decide/base/tests.py
@@ -12,9 +12,11 @@ from base import mods
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import NoSuchElementException
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 
-
+# Avoid timezone warnings
+USE_TZ = False
 
 class BaseTestCase(APITestCase):
 
@@ -178,8 +180,14 @@ class IndexViewTestCase(StaticLiveServerTestCase):
         self.driver.find_element(By.ID, "id_username").send_keys(user)
         self.driver.find_element(By.ID, "id_password").send_keys(password,Keys.ENTER)
 
-        vote_link = self.driver.find_element_by_link_text('Vote').get_attribute('href')
-        result_link = self.driver.find_element_by_link_text('Results').get_attribute('href')
+        try:
+            vote_link = self.driver.find_element_by_link_text('Vote').get_attribute('href')
+            result_link = self.driver.find_element_by_link_text('Results').get_attribute('href')
 
-        self.assertRegex(vote_link,'\/booth\/[0-9]*', msg='Vote link does not match the pattern "\/booth\/[0-9]*"')
-        self.assertRegex(result_link,'\/visualizer\/[0-9]*', msg='Results link does not match the pattern "\/visualizer\/[0-9]*"')
+            self.assertRegex(vote_link,'\/booth\/[0-9]*', msg='Vote link does not match the pattern "\/booth\/[0-9]*"')
+            self.assertRegex(result_link,'\/visualizer\/[0-9]*', msg='Results link does not match the pattern "\/visualizer\/[0-9]*"')
+        except:
+            self.assertRaises(NoSuchElementException,self.driver.find_element_by_link_text('Vote'), msg='Vote link not found')
+            self.assertRaises(NoSuchElementException,self.driver.find_element_by_link_text('Results'), msg='Results link not found')
+
+        

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -195,6 +195,12 @@ try:
 except ImportError:
     print("local_settings.py not found")
 
+#Secrets import, if secrets_settings file is not found it might affect some features
+try:
+    from secrets_settings import *
+except ImportError:
+    print("secrets_settings.py not found")
+
 # loading jsonnet config
 if os.path.exists("config.jsonnet"):
     import json

--- a/decide/decide/urls.py
+++ b/decide/decide/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
 ]
 
 for module in settings.MODULES:
-    print(module)
     urlpatterns += [
         path('{}/'.format(module), include('{}.urls'.format(module)))
     ]

--- a/decide/local_settings.example.py
+++ b/decide/local_settings.example.py
@@ -1,7 +1,3 @@
-from dotenv import dotenv_values
-
-secrets = dotenv_values(".secrets")
-
 ALLOWED_HOSTS = ["*"]
 
 # Modules in use, commented modules that you won't use
@@ -37,7 +33,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'decidedb',
-        'USER': 'decideusr',
+        'USER': 'decide',
         'PASSWORD':'complexpassword',
         'HOST': 'localhost',
         'PORT': '5432',
@@ -46,59 +42,3 @@ DATABASES = {
 
 # number of bits for the key, all auths should use the same number of bits
 KEYBITS = 256
-
-
-#Email SMTP
-EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp-mail.outlook.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = 'decide.part.aracena@outlook.com'
-EMAIL_HOST_PASSWORD = secrets['EMAIL_HOST_PASSWORD']
-
-SOCIALACCOUNT_PROVIDERS = {
-    'google': {
-        'APP': {
-            'client_id' : secrets['SOCIAL_AUTH_GOOGLE_CLIENT_ID'],
-            'secret': secrets['SOCIAL_AUTH_GOOGLE_SECRET'],
-            'key': '',
-        },
-        'SCOPE': [
-            'profile',
-            'email',
-        ],
-        'AUTH_PARAMS': {
-            'access_type': 'online',
-        },
-    },
-    'facebook': {
-        'APP': {
-            'client_id' : secrets['SOCIAL_AUTH_FACEBOOK_KEY'],
-            'secret': secrets['SOCIAL_AUTH_FACEBOOK_SECRET'],
-            'key': '',
-        },
-        'METHOD': 'oauth2',
-        'SCOPE': ['email', 'public_profile'],
-        'AUTH_PARAMS': {'auth_type': 'reauthenticate'},
-        'INIT_PARAMS': {'cookie': True},
-        'FIELDS': [
-            'id',
-            'first_name',
-            'last_name',
-            'middle_name',
-            'name',
-            'name_format',
-            'picture',
-            'short_name'
-        ],
-        'EXCHANGE_TOKEN': True,
-        'VERIFIED_EMAIL': False,
-        'VERSION': 'v13.0',
-    },
-    'discord': {
-        'APP': {
-            'client_id' : secrets['SOCIAL_AUTH_DISCORD_CLIENT_ID'],
-            'secret': secrets['SOCIAL_AUTH_DISCORD_SECRET'],
-            'key': '',
-        },
-    },
-}

--- a/decide/secrets_settings.example.py
+++ b/decide/secrets_settings.example.py
@@ -1,0 +1,66 @@
+#Email SMTP SECRETS
+EMAIL_HOST_PASSWORD = 'Ask the secrets administator to get secrets keys'
+
+# SOCIAL AUTH SECRETS
+SOCIAL_AUTH_DISCORD_CLIENT_ID = 'Ask the secrets administator to get secrets keys'
+SOCIAL_AUTH_DISCORD_SECRET = 'Ask the secrets administator to get secrets keys'
+SOCIAL_AUTH_FACEBOOK_KEY = 'Ask the secrets administator to get secrets keys'
+SOCIAL_AUTH_FACEBOOK_SECRET = 'Ask the secrets administator to get secrets keys'
+SOCIAL_AUTH_GOOGLE_CLIENT_ID = 'Ask the secrets administator to get secrets keys'
+SOCIAL_AUTH_GOOGLE_SECRET = 'Ask the secrets administator to get secrets keys'
+
+#Email SMTP
+EMAIL_USE_TLS = True
+EMAIL_HOST = 'smtp-mail.outlook.com'
+EMAIL_PORT = 587
+EMAIL_HOST_USER = 'decide.part.aracena@outlook.com'
+
+
+# SOCIAL AUTH
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'APP': {
+            'client_id' : SOCIAL_AUTH_GOOGLE_CLIENT_ID,
+            'secret': SOCIAL_AUTH_GOOGLE_SECRET,
+            'key': '',
+        },
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        },
+    },
+    'facebook': {
+        'APP': {
+            'client_id' : SOCIAL_AUTH_FACEBOOK_KEY,
+            'secret': SOCIAL_AUTH_FACEBOOK_SECRET,
+            'key': '',
+        },
+        'METHOD': 'oauth2',
+        'SCOPE': ['email', 'public_profile'],
+        'AUTH_PARAMS': {'auth_type': 'reauthenticate'},
+        'INIT_PARAMS': {'cookie': True},
+        'FIELDS': [
+            'id',
+            'first_name',
+            'last_name',
+            'middle_name',
+            'name',
+            'name_format',
+            'picture',
+            'short_name'
+        ],
+        'EXCHANGE_TOKEN': True,
+        'VERIFIED_EMAIL': False,
+        'VERSION': 'v13.0',
+    },
+    'discord': {
+        'APP': {
+            'client_id' : SOCIAL_AUTH_DISCORD_CLIENT_ID,
+            'secret': SOCIAL_AUTH_DISCORD_SECRET,
+            'key': '',
+        },
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ pandas==1.5.1
 django-import-export
 selenium
 django-allauth
-python-dotenv==0.21.0


### PR DESCRIPTION
Se han hecho tests de vistas para las funcionalidades #4 y #21.

Se ha hecho un cambio en la gestión de los secretos en los archivos de configuración. Cada desarrollador deberá hacer una copia local del archivo de ejemplo `secrets_settings.example.py` y pedir las claves a los administradores de claves (@lNoelia y @Josdelsan ) si quiere probar el funcionamiento de algunas funcionalidades. Las funcionalidades básicas de la aplicación pueden funcionar sin dicho archivo.